### PR TITLE
Allow filtering on multiple nodes

### DIFF
--- a/src/Visualizer.tsx
+++ b/src/Visualizer.tsx
@@ -46,7 +46,7 @@ import {
 } from "./react-aria-components-tailwind-starter/src/menu";
 import { useCopyToClipboard } from "./react-aria-components-tailwind-starter/src/hooks/use-clipboard";
 import { keepPreviousData, QueryClientProvider, useQuery } from "@tanstack/react-query";
-import { FlowClass, FlowEdge, FlowNode, layoutGraph, PreviousLayout, SelectedNode } from "./layout";
+import { FlowClass, FlowEdge, FlowNode, layoutGraph, PreviousLayout, SelectedNodes } from "./layout";
 import { queryClient } from "./queryClient";
 import { Loading } from "./Loading";
 import { Slider, SliderOutput, SliderTack } from "./react-aria-components-tailwind-starter/src/slider";
@@ -64,16 +64,17 @@ export function EClassNode({ data, selected }: NodeProps<FlowClass>) {
       <span>{value}</span>
     </div>
   ));
+  const border = data.selected ? "border-indigo-600" : "border-black";
   return (
     <div
-      className={`rounded-md border-dotted border-black h-full w-full ${selected ? "border-2" : "border"}`}
+      className={`rounded-md border-dotted ${border} h-full w-full ${selected ? "border-2" : "border"}`}
       style={{ backgroundColor: data.color! || "white" }}
       title={data.id}
     >
       <div className="p-1 font-mono">
         {...extra_nodes}
       </div>
-      <MyNodeToolbar type="class" id={data.id} />
+      <MyNodeToolbar type="class" id={data.id} selected={data.selected} />
       <Handle type="target" position={Position.Top} className="invisible" />
       <Handle type="source" position={Position.Bottom} className="invisible" />
     </div>
@@ -89,14 +90,16 @@ export function ENode(
   >
 ) {
   const subsumed = props?.data?.subsumed || false;
+  const selected = props?.data?.selected || false;
+  const outline = subsumed && selected ? "outline-indigo-100" : subsumed ? "outline-gray-300" : selected ? "outline-indigo-600" : "outline-black";
   return (
     <div
-      className={`p-1 rounded-md outline bg-white ${subsumed ? "outline-gray-300" : "outline-black"} h-full w-full ${
+      className={`p-1 rounded-md outline bg-white ${outline} h-full w-full ${
         props?.selected ? "outline-2" : "outline-1"
       }`}
       ref={props?.outerRef}
     >
-      {props?.outerRef ? <></> : <MyNodeToolbar type="node" id={props!.data!.id} />}
+      {props?.outerRef ? <></> : <MyNodeToolbar type="node" id={props!.data!.id} selected={selected} />}
 
       <div
         className={`font-mono text-base truncate max-w-96 min-w-6 text-center ${subsumed ? "text-gray-300" : ""}`}
@@ -111,7 +114,7 @@ export function ENode(
   );
 }
 
-export function MyNodeToolbar(node: { type: "class" | "node"; id: string }) {
+export function MyNodeToolbar(node: { type: "class" | "node"; id: string, selected: boolean }) {
   const selectNode = useContext(SetSelectedNodeContext);
   const onClick = useCallback(() => selectNode!(node), [selectNode, node]);
   return (
@@ -120,7 +123,7 @@ export function MyNodeToolbar(node: { type: "class" | "node"; id: string }) {
         onClick={onClick}
         className="rounded bg-white px-2 py-1 text-base font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
       >
-        Filter
+        {node.selected ? "Unfilter" : "Filter"}
       </button>
     </NodeToolbar>
   );
@@ -185,7 +188,7 @@ const proOptions = { hideAttribution: true };
 function Rendering({
   nodes: initialNodes,
   edges: initialEdges,
-  selectedNode: filteredNode,
+  selectedNodes: filteredNodes,
   nodeToEdges,
   edgeToNodes,
   elkJSON,
@@ -196,7 +199,7 @@ function Rendering({
 }: {
   nodes: (FlowNode | FlowClass)[];
   edges: FlowEdge[];
-  selectedNode: SelectedNode | null;
+  selectedNodes: SelectedNodes;
   nodeToEdges: Map<string, string[]>;
   edgeToNodes: Map<string, string[]>;
   elkJSON: string;
@@ -281,7 +284,7 @@ function Rendering({
       defaultEdgeOptions={defaultEdgeOptions}
       proOptions={proOptions}
     >
-      {filteredNode ? (
+      {filteredNodes.length > 0 ? (
         <Panel position="top-center">
           <button
             className="rounded bg-white px-2 py-1 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 hover:shadow-md hover:ring-gray-400 transition-all duration-200"
@@ -364,18 +367,37 @@ function LayoutFlow({
   const previousLayoutRef = useRef<PreviousLayout | null>(null);
   // e-class ID we have currently selected, store the first egraph string as well so we know if this selection is outdated,
   // if our whole list of egraphs changes, but keep the selection if we have simply added a new egraph on
-  const [selectedNodeWithEGraph, setSelectedNodeWithEGraph] = useState<(SelectedNode & { firstEgraph: string }) | null>(null);
-  const selectedNode = useMemo(() => {
-    if (selectedNodeWithEGraph && selectedNodeWithEGraph.firstEgraph === firstEgraph) {
-      return selectedNodeWithEGraph;
+  const [selectedNodesWithEGraph, setSelectedNodesWithEGraph] = useState<{selected: SelectedNodes, firstEgraph: string }>({selected: [], firstEgraph});
+  const selectedNodes = useMemo(() => {
+    if (selectedNodesWithEGraph && selectedNodesWithEGraph.firstEgraph === firstEgraph) {
+      return selectedNodesWithEGraph.selected;
     }
-    return null;
-  }, [selectedNodeWithEGraph, firstEgraph]);
-  const setSelectedNode = useCallback(
+    return [];
+  }, [selectedNodesWithEGraph, firstEgraph]);
+  // Callback to toggle whether the given node is selected
+  // if node is null, clear selection
+  const toggleSelectedNode = useCallback(
     (node: { type: "class" | "node"; id: string } | null) => {
-      setSelectedNodeWithEGraph(node ? { ...node, firstEgraph } : null);
+      if (!node) {
+        setSelectedNodesWithEGraph({ selected: [], firstEgraph });
+        return;
+      }
+      // If the e-graph has changed, reset selection
+      setSelectedNodesWithEGraph((prev) => {
+        if (prev.firstEgraph !== firstEgraph) {
+          return { selected: [node], firstEgraph };
+        }
+        const newSelected = [...prev.selected];
+        const index = newSelected.findIndex((n) => n.type === node.type && n.id === node.id);
+        if (index >= 0) {
+          newSelected.splice(index, 1);
+        } else {
+          newSelected.push(node);
+        }
+        return { selected: newSelected, firstEgraph };
+      });
     },
-    [setSelectedNodeWithEGraph, firstEgraph]
+    [setSelectedNodesWithEGraph, firstEgraph]
   );
 
   const getNodeSize = useCallback(
@@ -387,9 +409,9 @@ function LayoutFlow({
   );
   const previousLayout = useInteractiveLayout ? previousLayoutRef.current : null;
   const layoutQuery = useQuery({
-    queryKey: ["layout", egraph, getNodeSize, aspectRatio, selectedNode, previousLayout, mergeEdges],
+    queryKey: ["layout", egraph, getNodeSize, aspectRatio, selectedNodes, previousLayout, mergeEdges],
     networkMode: "always",
-    queryFn: ({ signal }) => layoutGraph(egraph, getNodeSize, aspectRatio, selectedNode, previousLayout, mergeEdges, signal),
+    queryFn: ({ signal }) => layoutGraph(egraph, getNodeSize, aspectRatio, selectedNodes, previousLayout, mergeEdges, signal),
     staleTime: Infinity,
     retry: false,
     retryOnMount: false,
@@ -413,14 +435,14 @@ function LayoutFlow({
   return (
     <>
       {layoutQuery.isFetching ? <Loading /> : <></>}
-      <SetSelectedNodeContext.Provider value={setSelectedNode}>
+      <SetSelectedNodeContext.Provider value={toggleSelectedNode}>
         <ReactFlowProvider>
           <Rendering
             nodes={nodes}
             edges={edges}
             nodeToEdges={nodeToEdges}
             edgeToNodes={edgeToNodes}
-            selectedNode={selectedNode}
+            selectedNodes={selectedNodes}
             elkJSON={elkJSON}
             useInteractiveLayout={useInteractiveLayout}
             setUseInteractiveLayout={setUseInteractiveLayout}

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -207,8 +207,8 @@ function toELKNode(
     classToNodes.get(node.eclass)!.push([id, node]);
   }
   /// filter out to descendants of the selected nodes
+  const toTraverse = new Set<string>();
   for (const selectedNode of selectedNodes) {
-    const toTraverse = new Set<string>();
     if (selectedNode.type === "class") {
       toTraverse.add(selectedNode.id);
     } else {
@@ -217,18 +217,20 @@ function toELKNode(
       // if we have selected a node, change the e-class to only include the selected node
       classToNodes.set(classID, [[selectedNode.id, egraph.nodes[selectedNode.id]]]);
     }
-    const traversed = new Set<string>();
-    while (toTraverse.size > 0) {
-      const current: string = toTraverse.values().next().value!;
-      toTraverse.delete(current);
-      traversed.add(current);
-      for (const childNode of classToNodes.get(current)!.flatMap(([, node]) => node.children || [])) {
-        const childClass = egraph.nodes[childNode].eclass;
-        if (!traversed.has(childClass)) {
-          toTraverse.add(childClass);
-        }
+  }
+  const traversed = new Set<string>();
+  while (toTraverse.size > 0) {
+    const current: string = toTraverse.values().next().value!;
+    toTraverse.delete(current);
+    traversed.add(current);
+    for (const childNode of classToNodes.get(current)!.flatMap(([, node]) => node.children || [])) {
+      const childClass = egraph.nodes[childNode].eclass;
+      if (!traversed.has(childClass)) {
+        toTraverse.add(childClass);
       }
     }
+  }
+  if (selectedNodes.length > 0) {
     for (const id of classToNodes.keys()) {
       if (!traversed.has(id)) {
         classToNodes.delete(id);

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -92,7 +92,7 @@ export type FlowClass = Node<
     color: string | null;
     id: string;
     extra: { [key: string]: string };
-    // selected?: boolean
+    selected: boolean;
   },
   "class"
 >;
@@ -101,7 +101,7 @@ export type FlowNode = Node<
     label: string;
     id: string;
     subsumed?: boolean;
-    // selected?: boolean
+    selected: boolean;
   },
   "node"
 >;
@@ -142,6 +142,7 @@ type Colors = Map<string | undefined, string | null>;
 
 export type PreviousLayout = { layout: MyELKNodeLayedOut; colors: Colors };
 export type SelectedNode = { type: "class" | "node"; id: string };
+export type SelectedNodes = SelectedNode[];
 
 /**
  * Transform a JSON egraph into the laid out nodes.
@@ -152,7 +153,7 @@ export async function layoutGraph(
   egraph: string,
   getNodeSize: (contents: string) => { width: number; height: number },
   aspectRatio: number,
-  selectedNode: SelectedNode | null,
+  selectedNodes: SelectedNodes,
   previousLayout: PreviousLayout | null,
   mergeEdges: boolean,
   signal: AbortSignal
@@ -165,7 +166,7 @@ export async function layoutGraph(
   layout: PreviousLayout;
 }> {
   const parsedEGraph = JSON.parse(egraph);
-  const { elkNode, colors } = toELKNode(parsedEGraph, getNodeSize, selectedNode, aspectRatio, previousLayout, mergeEdges);
+  const { elkNode, colors } = toELKNode(parsedEGraph, getNodeSize, selectedNodes, aspectRatio, previousLayout, mergeEdges);
   const elkJSON = JSON.stringify(elkNode, null, 2);
   const layout = (await layoutWithCancel(elkNode, signal)) as MyELKNodeLayedOut;
   const edges = toFlowEdges(layout);
@@ -191,7 +192,7 @@ export async function layoutGraph(
 function toELKNode(
   egraph: EGraph,
   getNodeSize: (contents: string) => { width: number; height: number },
-  selectedNode: SelectedNode | null,
+  selectedNodes: SelectedNodes,
   aspectRatio: number,
   previousLayout: PreviousLayout | null,
   mergeEdges: boolean
@@ -205,8 +206,8 @@ function toELKNode(
     }
     classToNodes.get(node.eclass)!.push([id, node]);
   }
-  /// filter out to descendants of the selected node
-  if (selectedNode) {
+  /// filter out to descendants of the selected nodes
+  for (const selectedNode of selectedNodes) {
     const toTraverse = new Set<string>();
     if (selectedNode.type === "class") {
       toTraverse.add(selectedNode.id);
@@ -285,16 +286,17 @@ function toELKNode(
   for (const [classID, nodes] of classToNodes.entries()) {
     const elkClassID = `class-${classID}`;
     const extra = class_data[classID] ? Object.fromEntries(Object.entries(class_data[classID]!).filter(([key]) => key !== "type")) : {};
+    const selected = selectedNodes.some((n) => n.type === "class" && n.id === classID);
     const elkClass: MyELKNode["children"][0] = {
       id: elkClassID,
-      data: { color: colors.get(class_data[classID]?.type)!, id: classID, extra },
+      data: { color: colors.get(class_data[classID]?.type)!, id: classID, extra, selected },
       layoutOptions: classLayoutOptions(Object.keys(extra).length),
       children: [],
       ports: mergeEdges
         ? []
         : (incomingEdges.get(classID) || []).map(({ nodeID, index }) => ({
-            id: `port-class-incoming-${nodeID}-${index}`,
-          })),
+          id: `port-class-incoming-${nodeID}-${index}`,
+        })),
 
       edges: [],
     };
@@ -302,9 +304,10 @@ function toELKNode(
     for (const [nodeID, node] of nodes) {
       const size = getNodeSize(node.op);
       const elkNodeID = `node-${nodeID}`;
+      const selected = selectedNodes.some((n) => n.type === "node" && n.id === nodeID);
       const elkNode: MyELKNode["children"][0]["children"][0] = {
         id: elkNodeID,
-        data: { label: node.op, id: nodeID, ...(node.subsumed ? { subsumed: true } : {}) },
+        data: { label: node.op, id: nodeID, ...(node.subsumed ? { subsumed: true } : {}), selected },
         width: size.width,
         height: size.height,
         ports: [],


### PR DESCRIPTION
This PR is meant to address #5 by allowing filtering on multiple nodes:


https://github.com/user-attachments/assets/1ea815d1-2afe-4fce-8aac-9e4002b914a1

However, I realize now that this implementation, where it takes the intersection of all nodes, is probably not we want.

Instead, I believe what we want is for filtering to one node in an e-class to be like "selecting" that e-node in an extraction. So I think the better behavior might be:

1. When selecting an e-node delete all other e-nodes in that e-class and only show nodes reachable from that e-node
2. When selecting multiple e-nodes, one must be reachable from the other. So again, delete all other e-nodes in the classes and find all reachable nodes.
3. When selecting an e-class, again find all reachable nodes of all e-nodes.

So really there is two types of filtering:

1. Choose a root e-class to filter everything under
2. Choose any number of e-nodes to filter to just the descendents of those

I will try to update this PR to reflect those changes


*Note that this work was requested and supported by @luminal-ai. Thank you!*